### PR TITLE
fix: svg validation without file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ app.post(
   '/upload',
   upload.single('image'),
   wrap(async (req, res, next) => {
-    console.log('req.file.path', req.file.path); // non svg extension file path
-    console.log('req.file.originalname', req.file.originalname); // => .svg
     const validationResult = validateMIMEType(req.file.path, {
       originalFilename: req.file.originalname,
       allowMimeTypes: ['image/jpeg', 'image/gif', 'image/png', 'image/svg+xml'],

--- a/src/validate-image-type.ts
+++ b/src/validate-image-type.ts
@@ -1,10 +1,18 @@
-import fs from "fs";
-
-import path from "path";
 import assert from "assert";
 import imageType from "image-type";
 import readChunk from "read-chunk";
 import isSvg from "is-svg";
+import * as fs from "fs";
+
+const isBinary = (buffer: Buffer): boolean => {
+    for (let i = 0; i < 24; i++) {
+        const characterCode = buffer[i];
+        if (characterCode === 65533 || characterCode <= 8) {
+            return true;
+        }
+    }
+    return false;
+};
 
 export type ValidateImageTypeOptions = {
     /**
@@ -28,27 +36,31 @@ export type ValidateImageResult = {
  * Detect the image type of a Buffer or Uint8Array
  * This check is based on https://github.com/sindresorhus/image-type
  */
-export function validateBufferMIMEType(
-    buffer: Buffer | Uint8Array,
-    options: ValidateImageTypeOptions
-): ValidateImageResult {
+export function validateBufferMIMEType(buffer: Buffer, options: ValidateImageTypeOptions): ValidateImageResult {
     const mimeTypes = options.allowMimeTypes;
     assert.ok(
         Array.isArray(mimeTypes) && mimeTypes.every((mimeType) => mimeType.includes("/")),
         `Should be set an array of mimeType. e.g.) ['image/jpeg']`
     );
-    const result = imageType(buffer);
-    if (!result) {
+    const imageTypeResult = imageType(buffer);
+    if (!imageTypeResult) {
         return {
             ok: false,
-            error: new Error("This buffer is not image"),
+            error: new Error(
+                `This buffer is not supported image. allowMimeTypes: ${JSON.stringify(mimeTypes)}` +
+                    (options.originalFilename ? `, filename: ${options.originalFilename}` : "")
+            ),
         };
     }
-    const isAllowed = mimeTypes.includes(result.mime);
+    const isAllowed = mimeTypes.includes(imageTypeResult.mime);
     if (!isAllowed) {
         return {
             ok: false,
-            error: new Error(`This buffer is disallowed image: ${result.mime}`),
+            error: new Error(
+                `This buffer is disallowed image MimeType: ${imageTypeResult.mime}, allowMimeTypes: ${JSON.stringify(
+                    mimeTypes
+                )}` + (options.originalFilename ? `,filename: ${options.originalFilename}` : "")
+            ),
         };
     }
     return {
@@ -71,24 +83,30 @@ export function validateBufferMIMEType(
  * ```
  */
 export function validateMIMEType(filePath: string, options: ValidateImageTypeOptions): ValidateImageResult {
-    const mimeTypes = options.allowMimeTypes;
-    // Handle SVG as special case
-    // https://github.com/sindresorhus/is-svg
-    const allowSVG = mimeTypes.includes("image/svg+xml");
-    const fileExt = path.extname(options.originalFilename ?? filePath);
-    if (allowSVG && fileExt === ".svg") {
-        const content = fs.readFileSync(filePath, "utf-8");
-        if (!isSvg(content)) {
+    // Use head buffer for performance reason
+    const buffer = readChunk.sync(filePath, 0, 24);
+    if (!isBinary(buffer)) {
+        const mimeTypes = options.allowMimeTypes;
+        // Handle SVG as special case
+        // https://github.com/sindresorhus/is-svg
+        const allowSVG = mimeTypes.includes("image/svg+xml");
+        if (allowSVG) {
+            // if the content is not binary, read all content and check it
+            // Note: Require 128 bytes at least one
+            const content = fs.readFileSync(filePath, "utf-8");
+            if (!isSvg(content)) {
+                return {
+                    ok: false,
+                    error: new Error(
+                        `This file is not svg. allowMimeTypes: ${JSON.stringify(mimeTypes)}` +
+                            (options.originalFilename ? `, filename: ${options.originalFilename}` : "")
+                    ),
+                };
+            }
             return {
-                ok: false,
-                error: new Error(`This file is not svg`),
+                ok: true,
             };
         }
-        return {
-            ok: true,
-        };
     }
-    // Use head buffer for performance reason
-    const buffer = readChunk.sync(filePath, 0, 12);
     return validateBufferMIMEType(buffer, options);
 }

--- a/src/validate-image-type.ts
+++ b/src/validate-image-type.ts
@@ -3,9 +3,9 @@ import imageType from "image-type";
 import readChunk from "read-chunk";
 import isSvg from "is-svg";
 import * as fs from "fs";
-
+const BINARY_READ_LENGTH = 24;
 const isBinary = (buffer: Buffer): boolean => {
-    for (let i = 0; i < 24; i++) {
+    for (let i = 0; i < BINARY_READ_LENGTH; i++) {
         const characterCode = buffer[i];
         if (characterCode === 65533 || characterCode <= 8) {
             return true;
@@ -84,7 +84,7 @@ export function validateBufferMIMEType(buffer: Buffer, options: ValidateImageTyp
  */
 export function validateMIMEType(filePath: string, options: ValidateImageTypeOptions): ValidateImageResult {
     // Use head buffer for performance reason
-    const buffer = readChunk.sync(filePath, 0, 24);
+    const buffer = readChunk.sync(filePath, 0, BINARY_READ_LENGTH);
     if (!isBinary(buffer)) {
         const mimeTypes = options.allowMimeTypes;
         // Handle SVG as special case

--- a/test/validate-image-type.test.ts
+++ b/test/validate-image-type.test.ts
@@ -22,6 +22,13 @@ describe("validate-image-type", function () {
         });
         assert.ok(result.ok);
     });
+    it("validate svg images without originalFilename", () => {
+        // without .svg
+        const result = validateMIMEType(path.join(__dirname, "fixtures/svg-but-non-svg-ext"), {
+            allowMimeTypes: ["image/svg+xml"],
+        });
+        assert.ok(result.ok);
+    });
     it("return an error if the images is invalid", () => {
         const result = validateMIMEType(path.join(__dirname, "fixtures/invalid.png"), {
             allowMimeTypes: ["image/png"],

--- a/test/validate-image-type.test.ts
+++ b/test/validate-image-type.test.ts
@@ -27,20 +27,23 @@ describe("validate-image-type", function () {
             allowMimeTypes: ["image/png"],
         });
         assert.strictEqual(result.ok, false);
-        assert.strictEqual(result.error?.message, "This buffer is not image");
+        assert.strictEqual(result.error?.message, `This buffer is not supported image. allowMimeTypes: ["image/png"]`);
     });
     it("return an error if the images is not svg", () => {
         const result = validateMIMEType(path.join(__dirname, "fixtures/invalid.svg"), {
             allowMimeTypes: ["image/svg+xml"],
         });
         assert.strictEqual(result.ok, false);
-        assert.strictEqual(result.error?.message, "This file is not svg");
+        assert.strictEqual(result.error?.message, `This file is not svg. allowMimeTypes: ["image/svg+xml"]`);
     });
     it("return an error when the images is not allowed", () => {
         const result = validateMIMEType(path.join(__dirname, "fixtures/valid.png"), {
             allowMimeTypes: [],
         });
         assert.strictEqual(result.ok, false);
-        assert.strictEqual(result.error?.message, "This buffer is disallowed image: image/png");
+        assert.strictEqual(
+            result.error?.message,
+            "This buffer is disallowed image MimeType: image/png, allowMimeTypes: []"
+        );
     });
 });


### PR DESCRIPTION
It relaxes SVG validation.

fix #1 