### PR TITLE
fix: update file-type@16 and change to async API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node_version: [ 14, 16, 18 ]
+        node-version: [ 14, 16, 18 ]
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: setup Node.js ${{ matrix.node_version }}
+      - name: setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
-          node_version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.node-version }}
       - name: Install
         run: yarn install
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,16 +4,16 @@ env:
   CI: true
 jobs:
   test:
-    name: "Test on Node.js ${{ matrix.node_version }}"
+    name: "Test on Node.js ${{ matrix.node-version }}"
     runs-on: ubuntu-18.04
     strategy:
       matrix:
         node-version: [ 14, 16, 18 ]
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ env:
 jobs:
   test:
     name: "Test on Node.js ${{ matrix.node-version }}"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [ 14, 16, 18 ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Check the image file of a Buffer/Uint8Array that matched expected image MIME-typ
 
 This library check the **file contents** instead of **file extensions** using following:
 
-- [sindresorhus/image-type: Detect the image type of a Buffer/Uint8Array](https://github.com/sindresorhus/image-type)
+- [sindresorhus/file-type: Detect the file type of a Buffer/Uint8Array/ArrayBuffer](https://github.com/sindresorhus/file-type)
 - [sindresorhus/is-svg: Check if a string or buffer is SVG](https://github.com/sindresorhus/is-svg)
 
 ## Features
@@ -22,7 +22,7 @@ Install with [npm](https://www.npmjs.com/):
 
 ```ts
 import { validateMIMEType } from "validate-image-type";
-const result = validateMIMEType("./image.png", {
+const result = await validateMIMEType("./image.png", {
     allowMimeTypes: ['image/jpeg', 'image/gif', 'image/png', 'image/svg+xml']
 });
 if (!result.ok) {
@@ -50,11 +50,17 @@ Integration with [Multer](https://github.com/expressjs/multer) middleware.
 const multer = require('multer');
 const temp_local_img_dir = path.join(__dirname, `/.temp_local_img_dir`);
 const upload = multer({ dest: temp_local_img_dir });
+const asyncWrapper = fn => {
+    return (req, res, next) => {
+        return fn(req, res, next).catch(next);
+    }
+};
+
 app.post(
   '/upload',
-  upload.single('image'),
-  (req, res, next) => {
-    const validationResult = validateMIMEType(req.file.path, {
+  upload.single('image'), 
+  asyncWrapper(async (req, res, next) => {
+    const validationResult = await validateMIMEType(req.file.path, {
       originalFilename: req.file.originalname,
       allowMimeTypes: ['image/jpeg', 'image/gif', 'image/png', 'image/svg+xml'],
     });
@@ -64,7 +70,7 @@ app.post(
     }
     // uploading task
     // ...
-  }
+  })
 );
 ```
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "test"
   },
   "scripts": {
-    "build": "cross-env NODE_ENV=production tsc -p .",
+    "build": "tsc -p .",
     "clean": "rimraf lib/",
     "prepublish": "npm run --if-present build",
     "test": "mocha \"test/**/*.ts\"",
@@ -60,14 +60,13 @@
     "trailingComma": "none"
   },
   "dependencies": {
-    "image-type": "^4.1.0",
+    "file-type": "^16.5.4",
     "is-svg": "^4.2.1",
     "read-chunk": "^3.2.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.0.6",
-    "cross-env": "^7.0.2",
     "lint-staged": "^13.0.3",
     "mocha": "^10.0.0",
     "prettier": "^2.7.1",

--- a/src/image-type.ts
+++ b/src/image-type.ts
@@ -1,0 +1,30 @@
+import { fromBuffer } from "file-type";
+
+const imageExts = new Set([
+    "jpg",
+    "png",
+    "gif",
+    "webp",
+    "flif",
+    "cr2",
+    "tif",
+    "bmp",
+    "jxr",
+    "psd",
+    "ico",
+    "bpg",
+    "jp2",
+    "jpm",
+    "jpx",
+    "heic",
+    "cur",
+    "dcm"
+]);
+
+export const imageType = async (buffer: Buffer | Uint8Array | ArrayBuffer) => {
+    const ret = await fromBuffer(buffer);
+    if (!ret) {
+        return null;
+    }
+    return imageExts.has(ret.ext) ? ret : null;
+};

--- a/src/isBinary.ts
+++ b/src/isBinary.ts
@@ -1,0 +1,10 @@
+export const BINARY_READ_LENGTH = 24;
+export const isBinary = (buffer: Buffer): boolean => {
+    for (let i = 0; i < BINARY_READ_LENGTH; i++) {
+        const characterCode = buffer[i];
+        if (characterCode === 65533 || characterCode <= 8) {
+            return true;
+        }
+    }
+    return false;
+};

--- a/test/validate-image-type.test.ts
+++ b/test/validate-image-type.test.ts
@@ -4,48 +4,48 @@ import * as assert from "assert";
 import fs from "fs";
 
 describe("validate-image-type", function () {
-    it("validate valid images", () => {
-        const result = validateMIMEType(path.join(__dirname, "fixtures/valid.png"), {
+    it("validate valid images", async () => {
+        const result = await validateMIMEType(path.join(__dirname, "fixtures/valid.png"), {
             allowMimeTypes: ["image/png"]
         });
         assert.ok(result.ok);
     });
-    it("validate svg images", () => {
-        const result = validateMIMEType(path.join(__dirname, "fixtures/valid.svg"), {
+    it("validate svg images", async () => {
+        const result = await validateMIMEType(path.join(__dirname, "fixtures/valid.svg"), {
             allowMimeTypes: ["image/svg+xml"]
         });
         assert.ok(result.ok);
     });
-    it("validate svg images with originalFilename", () => {
-        const result = validateMIMEType(path.join(__dirname, "fixtures/svg-but-non-svg-ext"), {
+    it("validate svg images with originalFilename", async () => {
+        const result = await validateMIMEType(path.join(__dirname, "fixtures/svg-but-non-svg-ext"), {
             originalFilename: "test.svg",
             allowMimeTypes: ["image/svg+xml"]
         });
         assert.ok(result.ok);
     });
-    it("validate svg images without originalFilename", () => {
+    it("validate svg images without originalFilename", async () => {
         // without .svg
-        const result = validateMIMEType(path.join(__dirname, "fixtures/svg-but-non-svg-ext"), {
+        const result = await validateMIMEType(path.join(__dirname, "fixtures/svg-but-non-svg-ext"), {
             allowMimeTypes: ["image/svg+xml"]
         });
         assert.ok(result.ok);
     });
-    it("return an error if the images is invalid", () => {
-        const result = validateMIMEType(path.join(__dirname, "fixtures/invalid.png"), {
+    it("return an error if the images is invalid", async () => {
+        const result = await validateMIMEType(path.join(__dirname, "fixtures/invalid.png"), {
             allowMimeTypes: ["image/png"]
         });
         assert.strictEqual(result.ok, false);
         assert.strictEqual(result.error?.message, `This buffer is not supported image. allowMimeTypes: ["image/png"]`);
     });
-    it("return an error if the images is not svg", () => {
-        const result = validateMIMEType(path.join(__dirname, "fixtures/invalid.svg"), {
+    it("return an error if the images is not svg", async () => {
+        const result = await validateMIMEType(path.join(__dirname, "fixtures/invalid.svg"), {
             allowMimeTypes: ["image/svg+xml"]
         });
         assert.strictEqual(result.ok, false);
         assert.strictEqual(result.error?.message, `This file is not svg. allowMimeTypes: ["image/svg+xml"]`);
     });
-    it("return an error when the images is not allowed", () => {
-        const result = validateMIMEType(path.join(__dirname, "fixtures/valid.png"), {
+    it("return an error when the images is not allowed", async () => {
+        const result = await validateMIMEType(path.join(__dirname, "fixtures/valid.png"), {
             allowMimeTypes: []
         });
         assert.strictEqual(result.ok, false);
@@ -54,41 +54,47 @@ describe("validate-image-type", function () {
             "This buffer is disallowed image MimeType: image/png, allowMimeTypes: []"
         );
     });
-    it("validate valid image buffer", () => {
-        const result = validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/valid.png")), {
+    it("validate valid image buffer", async () => {
+        const result = await validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/valid.png")), {
             allowMimeTypes: ["image/png"]
         });
         assert.ok(result.ok);
     });
-    it("validate svg image buffer", () => {
-        const result = validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/valid.svg")), {
+    it("validate svg image buffer", async () => {
+        const result = await validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/valid.svg")), {
             allowMimeTypes: ["image/svg+xml"]
         });
         assert.ok(result.ok);
     });
-    it("validate svg image buffer with originalFilename", () => {
-        const result = validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/svg-but-non-svg-ext")), {
-            originalFilename: "test.svg",
-            allowMimeTypes: ["image/svg+xml"]
-        });
+    it("validate svg image buffer with originalFilename", async () => {
+        const result = await validateBufferMIMEType(
+            fs.readFileSync(path.join(__dirname, "fixtures/svg-but-non-svg-ext")),
+            {
+                originalFilename: "test.svg",
+                allowMimeTypes: ["image/svg+xml"]
+            }
+        );
         assert.ok(result.ok);
     });
-    it("validate svg image buffer without originalFilename", () => {
+    it("validate svg image buffer without originalFilename", async () => {
         // without .svg
-        const result = validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/svg-but-non-svg-ext")), {
-            allowMimeTypes: ["image/svg+xml"]
-        });
+        const result = await validateBufferMIMEType(
+            fs.readFileSync(path.join(__dirname, "fixtures/svg-but-non-svg-ext")),
+            {
+                allowMimeTypes: ["image/svg+xml"]
+            }
+        );
         assert.ok(result.ok);
     });
-    it("return an error if the image buffer is invalid", () => {
-        const result = validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/invalid.png")), {
+    it("return an error if the image buffer is invalid", async () => {
+        const result = await validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/invalid.png")), {
             allowMimeTypes: ["image/png"]
         });
         assert.strictEqual(result.ok, false);
         assert.strictEqual(result.error?.message, `This buffer is not supported image. allowMimeTypes: ["image/png"]`);
     });
-    it("return an error if the image buffer is not svg", () => {
-        const result = validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/invalid.svg")), {
+    it("return an error if the image buffer is not svg", async () => {
+        const result = await validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/invalid.svg")), {
             allowMimeTypes: ["image/svg+xml"]
         });
         assert.strictEqual(result.ok, false);
@@ -97,8 +103,8 @@ describe("validate-image-type", function () {
             `This buffer is not supported image. allowMimeTypes: ["image/svg+xml"]`
         );
     });
-    it("return an error when the image buffer is not allowed", () => {
-        const result = validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/valid.png")), {
+    it("return an error when the image buffer is not allowed", async () => {
+        const result = await validateBufferMIMEType(fs.readFileSync(path.join(__dirname, "fixtures/valid.png")), {
             allowMimeTypes: []
         });
         assert.strictEqual(result.ok, false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,14 +330,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-env@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
-  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
-  dependencies:
-    cross-spawn "^7.0.1"
-
-cross-spawn@^7.0.1, cross-spawn@^7.0.3:
+cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -427,7 +420,7 @@ fast-xml-parser@^3.19.0:
   dependencies:
     strnum "^1.0.4"
 
-file-type@16:
+file-type@^16.5.4:
   version "16.5.4"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.4.tgz#474fb4f704bee427681f98dd390058a172a6c2fd"
   integrity sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,6 +48,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@tokenizer/token@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
+  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
@@ -422,10 +427,14 @@ fast-xml-parser@^3.19.0:
   dependencies:
     strnum "^1.0.4"
 
-file-type@^10.10.0:
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-10.11.0.tgz#2961d09e4675b9fb9a3ee6b69e9cd23f43fd1890"
-  integrity sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==
+file-type@16:
+  version "16.5.4"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.4.tgz#474fb4f704bee427681f98dd390058a172a6c2fd"
+  integrity sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==
+  dependencies:
+    readable-web-to-node-stream "^3.0.0"
+    strtok3 "^6.2.4"
+    token-types "^4.1.1"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -535,12 +544,10 @@ human-signals@^3.0.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
   integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
 
-image-type@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/image-type/-/image-type-4.1.0.tgz#72a88d64ff5021371ed67b9a466442100be57cd1"
-  integrity sha512-CFJMJ8QK8lJvRlTCEgarL4ro6hfDQKif2HjSvYCdQZESaIPV4v9imrf7BQHK+sQeTeNeMpWciR9hyC/g8ybXEg==
-  dependencies:
-    file-type "^10.10.0"
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -555,7 +562,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -917,6 +924,11 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+peek-readable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.1.0.tgz#4ece1111bf5c2ad8867c314c81356847e8a62e72"
+  integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -961,6 +973,22 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
+
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-web-to-node-stream@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz#5d52bb5df7b54861fd48d015e93a2cb87b3ee0bb"
+  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
+  dependencies:
+    readable-stream "^3.6.0"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -1010,7 +1038,7 @@ rxjs@^7.5.5:
   dependencies:
     tslib "^2.1.0"
 
-safe-buffer@^5.1.0:
+safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -1119,6 +1147,13 @@ string-width@^5.0.0:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -1147,6 +1182,14 @@ strnum@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
   integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+
+strtok3@^6.2.4:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.3.0.tgz#358b80ffe6d5d5620e19a073aa78ce947a90f9a0"
+  integrity sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    peek-readable "^4.1.0"
 
 supports-color@8.1.1:
   version "8.1.1"
@@ -1185,6 +1228,14 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+token-types@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-4.2.0.tgz#b66bc3d67420c6873222a424eee64a744f4c2f13"
+  integrity sha512-P0rrp4wUpefLncNamWIef62J0v0kQR/GfDVji9WKY7GDCWy5YbVSrKUTam07iWPZQGy0zWNOfstYTykMmPNR7w==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    ieee754 "^1.2.1"
 
 ts-node-test-register@^10.0.0:
   version "10.0.0"
@@ -1231,6 +1282,11 @@ typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
BREAKING CHANGE: export API as async function

- require Node.js 14+
- use file-type instead of image-type
  - image-type is not updated
- make async api
   - file-type no more expose sync api https://github.com/sindresorhus/file-type/releases/tag/v13.0.0